### PR TITLE
chore(server): add testing dependencies

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,15 +5,23 @@
   "type": "module",
   "scripts": {
     "dev": "node --watch src/server.js",
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.1.5",
     "form-data": "^4.0.0",
     "jose": "^5.9.6",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "@types/jest": "^29.5.8"
   }
 }


### PR DESCRIPTION
## Summary
- add test and rate limiting deps to server package.json

## Testing
- `npm --prefix apps/server test -- --watchAll=false` *(fails: jest not found after install failure)*

------
https://chatgpt.com/codex/tasks/task_b_68a0f9810d64833292aaf64d28ef6c7c