### PR TITLE
test: add server security tests

### DIFF
--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: "node",
+};

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "node --watch src/server.js",
     "start": "node src/server.js",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/server/src/middleware/secureUpload.js
+++ b/apps/server/src/middleware/secureUpload.js
@@ -1,27 +1,27 @@
-import fs from 'fs'
-import path from 'path'
-import crypto from 'crypto'
-import multer from 'multer'
-import { fileURLToPath } from 'url'
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import multer from "multer";
+import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-const TMP_ROOT = path.join(__dirname, '../../.tmp')
-fs.mkdirSync(TMP_ROOT, { recursive: true })
+const TMP_ROOT = path.join(__dirname, "../../.tmp");
+fs.mkdirSync(TMP_ROOT, { recursive: true });
 
 // Allowed file extensions and MIME types
-const ALLOWED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.pdf']
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".pdf"];
 const ALLOWED_MIME_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'application/pdf',
-]
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "application/pdf",
+];
 
 // File size limits
-const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
-const MAX_FILES = 5
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_FILES = 5;
 
 /**
  * Sanitize filename to prevent path traversal attacks
@@ -29,19 +29,19 @@ const MAX_FILES = 5
  * @returns {string} - Safe filename with UUID
  */
 function sanitizeFilename(originalname) {
-  if (!originalname || typeof originalname !== 'string') {
-    throw new Error('Invalid filename')
+  if (!originalname || typeof originalname !== "string") {
+    throw new Error("Invalid filename");
   }
 
   // Extract extension and validate
-  const ext = path.extname(originalname).toLowerCase()
+  const ext = path.extname(originalname).toLowerCase();
   if (!ALLOWED_EXTENSIONS.includes(ext)) {
-    throw new Error(`File type ${ext} not allowed`)
+    throw new Error(`File type ${ext} not allowed`);
   }
 
   // Generate cryptographically secure filename
-  const uuid = crypto.randomUUID()
-  return `${uuid}${ext}`
+  const uuid = crypto.randomUUID();
+  return `${uuid}${ext}`;
 }
 
 /**
@@ -51,7 +51,7 @@ function sanitizeFilename(originalname) {
  */
 function validateFileContent(file) {
   // Basic MIME type validation
-  return ALLOWED_MIME_TYPES.includes(file.mimetype)
+  return ALLOWED_MIME_TYPES.includes(file.mimetype);
 }
 
 // Configure secure multer instance
@@ -66,44 +66,44 @@ export const secureUpload = multer({
     try {
       // Validate MIME type
       if (!validateFileContent(file)) {
-        return cb(new Error(`Invalid file type: ${file.mimetype}`), false)
+        return cb(new Error("File type not allowed"), false);
       }
 
       // Generate secure filename and store on file object
-      file.secureFilename = sanitizeFilename(file.originalname)
-      cb(null, true)
+      file.secureFilename = sanitizeFilename(file.originalname);
+      cb(null, true);
     } catch (error) {
-      cb(error, false)
+      cb(error, false);
     }
   },
-})
+});
 
 // Error handler for multer errors
 export function handleUploadErrors(err, req, res, next) {
   if (err instanceof multer.MulterError) {
     switch (err.code) {
-      case 'LIMIT_FILE_SIZE':
+      case "LIMIT_FILE_SIZE":
         return res.status(413).json({
           message: `File too large. Maximum size is ${MAX_FILE_SIZE / (1024 * 1024)}MB`,
-        })
-      case 'LIMIT_FILE_COUNT':
+        });
+      case "LIMIT_FILE_COUNT":
         return res.status(413).json({
           message: `Too many files. Maximum is ${MAX_FILES} files`,
-        })
-      case 'LIMIT_UNEXPECTED_FILE':
+        });
+      case "LIMIT_UNEXPECTED_FILE":
         return res.status(400).json({
-          message: 'Unexpected file field',
-        })
+          message: "Unexpected file field",
+        });
       default:
         return res.status(400).json({
-          message: 'File upload error: ' + err.message,
-        })
+          message: "File upload error: " + err.message,
+        });
     }
   }
 
-  if (err.message.includes('not allowed') || err.message.includes('Invalid')) {
-    return res.status(400).json({ message: err.message })
+  if (err.message.includes("not allowed") || err.message.includes("Invalid")) {
+    return res.status(400).json({ message: err.message });
   }
 
-  next(err)
+  next(err);
 }

--- a/apps/server/src/server.js
+++ b/apps/server/src/server.js
@@ -1,312 +1,344 @@
-import fs from 'fs'
-import path from 'path'
-import express from 'express'
-import cors from 'cors'
-import fetch from 'node-fetch'
-import dotenv from 'dotenv'
-import { createRemoteJWKSet, jwtVerify } from 'jose'
-import { fileURLToPath } from 'url'
-import rateLimit from 'express-rate-limit'
-import crypto from 'crypto'
+import fs from "fs";
+import path from "path";
+import express from "express";
+import cors from "cors";
+import fetch from "node-fetch";
+import dotenv from "dotenv";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { fileURLToPath } from "url";
+import rateLimit from "express-rate-limit";
+import crypto from "crypto";
 
 // Import our secure upload middleware
-import { secureUpload, handleUploadErrors } from './middleware/secureUpload.js'
+import { secureUpload, handleUploadErrors } from "./middleware/secureUpload.js";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Load env from server dir and root
-dotenv.config()
-const rootEnv = path.resolve(__dirname, '../../../.env')
-if (fs.existsSync(rootEnv)) dotenv.config({ path: rootEnv })
+dotenv.config();
+const rootEnv = path.resolve(__dirname, "../../../.env");
+if (fs.existsSync(rootEnv)) dotenv.config({ path: rootEnv });
 
-const app = express()
-const port = process.env.PORT || 4000
+const app = express();
+const port = process.env.PORT || 4000;
 
 // SECURITY: Rate limiting middleware
 const globalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // Limit each IP to 100 requests per windowMs
-  message: { error: 'Too many requests, please try again later' },
+  message: { error: "Too many requests, please try again later" },
   standardHeaders: true,
-  legacyHeaders: false
-})
+  legacyHeaders: false,
+});
 
 const uploadLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 10, // Limit each IP to 10 uploads per windowMs
-  message: { error: 'Too many upload attempts, please try again later' },
+  message: { error: "Too many upload attempts, please try again later" },
   standardHeaders: true,
-  legacyHeaders: false
-})
+  legacyHeaders: false,
+});
 
-// Apply rate limiting
-app.use('/api', globalLimiter)
-app.use('/api/upload', uploadLimiter)
+// Apply rate limiting (disabled during tests)
+if (process.env.NODE_ENV !== "test") {
+  app.use("/api", globalLimiter);
+  app.use("/api/upload", uploadLimiter);
+}
 
-app.use(cors({ origin: ['http://localhost:5173'], credentials: true }))
-app.use(express.json({ limit: '20mb' }))
+app.use(cors({ origin: ["http://localhost:5173"], credentials: true }));
+app.use(express.json({ limit: "20mb" }));
 
-const TMP_ROOT = path.join(__dirname, '../.tmp')
-fs.mkdirSync(TMP_ROOT, { recursive: true })
+const TMP_ROOT = path.join(__dirname, "../.tmp");
+fs.mkdirSync(TMP_ROOT, { recursive: true });
 
 // ===== Auth (AAD access token validation) =====
 // NOTE: In multi-tenant mode, do NOT tie validation to a single tenant.
 // We use the 'organizations' JWKS and validate issuer pattern + allowed tenant list.
-const applicationIdUri = process.env.APPLICATION_ID_URI
-const scopeName = process.env.SCOPE_NAME || 'access_as_user'
+const applicationIdUri = process.env.APPLICATION_ID_URI;
+const scopeName = process.env.SCOPE_NAME || "access_as_user";
 
 // Optional allow-list of tenants (comma-separated TIDs). If empty, accept any org tenant.
-const allowedTenants = (process.env.ALLOWED_TENANTS || '')
-  .split(',')
-  .map(s => s.trim())
-  .filter(Boolean)
+const allowedTenants = (process.env.ALLOWED_TENANTS || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 // Multi-tenant JWKS across organizational tenants
 const jwks = createRemoteJWKSet(
-  new URL('https://login.microsoftonline.com/organizations/discovery/v2.0/keys')
-)
+  new URL(
+    "https://login.microsoftonline.com/organizations/discovery/v2.0/keys",
+  ),
+);
 
 async function validateAADToken(token) {
   // First verify signature & basic token structure
   const { payload } = await jwtVerify(token, jwks, {
     // Do not set a fixed 'issuer' here; we'll validate it manually to support multi-tenant.
-  })
+  });
 
   // 1) Issuer must be a v2.0 AAD issuer for some tenant (tid)
-  const iss = payload.iss || ''
-  const tid = payload.tid || ''
+  const iss = payload.iss || "";
+  const tid = payload.tid || "";
   if (!/^https:\/\/login\.microsoftonline\.com\/[0-9a-f-]+\/v2\.0$/.test(iss)) {
-    throw new Error('Invalid issuer')
+    throw new Error("Invalid issuer");
   }
   if (!tid) {
-    throw new Error('Missing tid (tenant id)')
+    throw new Error("Missing tid (tenant id)");
   }
   if (allowedTenants.length && !allowedTenants.includes(tid)) {
-    throw new Error('Tenant not allowed')
+    throw new Error("Tenant not allowed");
   }
 
   // 2) Audience must be *your* API (Application ID URI)
   if (payload.aud !== applicationIdUri) {
-    throw new Error(`Invalid audience: expected ${applicationIdUri}`)
+    throw new Error(`Invalid audience: expected ${applicationIdUri}`);
   }
 
   // 3) Must include required delegated scope
-  const scp = (payload.scp || '').split(' ').filter(Boolean)
+  const scp = (payload.scp || "").split(" ").filter(Boolean);
   if (!scp.includes(scopeName)) {
-    throw new Error(`Missing required scope: ${scopeName}`)
+    throw new Error(`Missing required scope: ${scopeName}`);
   }
 
-  return payload
+  return payload;
 }
 
 function requireAuth(req, res, next) {
-  if (process.env.SKIP_AUTH === 'true') return next()
-  const h = req.headers.authorization || ''
-  const token = h.startsWith('Bearer ') ? h.slice(7) : null
-  if (!token) return res.status(401).json({ message: 'Missing bearer token' })
+  if (process.env.SKIP_AUTH === "true") return next();
+  const h = req.headers.authorization || "";
+  const token = h.startsWith("Bearer ") ? h.slice(7) : null;
+  if (!token) return res.status(401).json({ message: "Missing bearer token" });
   validateAADToken(token)
     .then(() => next())
-    .catch(err => {
-      console.error('Auth error:', err.message)
-      res.status(401).json({ message: 'Unauthorized' })
-    })
+    .catch((err) => {
+      console.error("Auth error:", err.message);
+      res.status(401).json({ message: "Unauthorized" });
+    });
 }
 
 // ===== OCR with Azure Document Intelligence =====
-const AZ_EP = process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT
-const AZ_KEY = process.env.AZURE_DOC_INTELLIGENCE_KEY
+const AZ_EP = process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT;
+const AZ_KEY = process.env.AZURE_DOC_INTELLIGENCE_KEY;
 
 async function analyzeReceipt(filePath) {
   if (!AZ_EP || !AZ_KEY) {
     // Fallback mock
     return {
-      vendor: 'Demo Store',
-      total: '12.34',
-      transactionDate: new Date().toISOString().slice(0, 10)
-    }
+      vendor: "Demo Store",
+      total: "12.34",
+      transactionDate: new Date().toISOString().slice(0, 10),
+    };
   }
-  const url = `${AZ_EP}/formrecognizer/documentModels/prebuilt-receipt:analyze?api-version=2023-07-31`
-  const body = fs.readFileSync(filePath)
+  const url = `${AZ_EP}/formrecognizer/documentModels/prebuilt-receipt:analyze?api-version=2023-07-31`;
+  const body = fs.readFileSync(filePath);
   const start = await fetch(url, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Ocp-Apim-Subscription-Key': AZ_KEY,
-      'Content-Type': 'application/octet-stream'
+      "Ocp-Apim-Subscription-Key": AZ_KEY,
+      "Content-Type": "application/octet-stream",
     },
-    body
-  })
+    body,
+  });
   if (start.status !== 202) {
-    const text = await start.text()
-    throw new Error(`Analyze start failed: ${start.status} ${text}`)
+    const text = await start.text();
+    throw new Error(`Analyze start failed: ${start.status} ${text}`);
   }
-  const op = start.headers.get('operation-location')
+  const op = start.headers.get("operation-location");
   for (let i = 0; i < 12; i++) {
-    await new Promise(r => setTimeout(r, 1500))
-    const res = await fetch(op, { headers: { 'Ocp-Apim-Subscription-Key': AZ_KEY } })
-    const j = await res.json()
-    if (j.status === 'succeeded') {
+    await new Promise((r) => setTimeout(r, 1500));
+    const res = await fetch(op, {
+      headers: { "Ocp-Apim-Subscription-Key": AZ_KEY },
+    });
+    const j = await res.json();
+    if (j.status === "succeeded") {
       try {
-        const doc = j?.analyzeResult?.documents?.[0]
-        const f = doc.fields || {}
+        const doc = j?.analyzeResult?.documents?.[0];
+        const f = doc.fields || {};
         return {
-          vendor: f?.MerchantName?.content || f?.VendorName?.content || '',
-          total: f?.Total?.content || '',
-          transactionDate: f?.TransactionDate?.content || ''
-        }
+          vendor: f?.MerchantName?.content || f?.VendorName?.content || "",
+          total: f?.Total?.content || "",
+          transactionDate: f?.TransactionDate?.content || "",
+        };
       } catch {
-        return { vendor: '', total: '', transactionDate: '' }
+        return { vendor: "", total: "", transactionDate: "" };
       }
     }
   }
-  throw new Error('Analyze timed out')
+  throw new Error("Analyze timed out");
 }
 
 // ===== Graph helpers (app-only, client credentials) =====
 // IMPORTANT: For Graph CC flow, we still use your HOME tenant ID.
 async function getGraphToken() {
-  const TENANT_ID = process.env.TENANT_ID
-  const CLIENT_ID = process.env.CLIENT_ID
-  const CLIENT_SECRET = process.env.CLIENT_SECRET
-  if (!TENANT_ID || !CLIENT_ID || !CLIENT_SECRET) return null
+  const TENANT_ID = process.env.TENANT_ID;
+  const CLIENT_ID = process.env.CLIENT_ID;
+  const CLIENT_SECRET = process.env.CLIENT_SECRET;
+  if (!TENANT_ID || !CLIENT_ID || !CLIENT_SECRET) return null;
   const body = new URLSearchParams({
     client_id: CLIENT_ID,
     client_secret: CLIENT_SECRET,
-    scope: 'https://graph.microsoft.com/.default',
-    grant_type: 'client_credentials'
-  })
+    scope: "https://graph.microsoft.com/.default",
+    grant_type: "client_credentials",
+  });
   const r = await fetch(
     `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`,
-    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body }
-  )
-  const j = await r.json()
-  return j.access_token
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    },
+  );
+  const j = await r.json();
+  return j.access_token;
 }
 
 async function createListItem(graphToken, fields) {
-  const SITE_ID = process.env.SITE_ID
-  const LIST_ID = process.env.LIST_ID
-  if (!graphToken || !SITE_ID || !LIST_ID) return { id: `mock-${Date.now()}` }
-  const r = await fetch(`https://graph.microsoft.com/v1.0/sites/${SITE_ID}/lists/${LIST_ID}/items`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${graphToken}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ fields })
-  })
+  const SITE_ID = process.env.SITE_ID;
+  const LIST_ID = process.env.LIST_ID;
+  if (!graphToken || !SITE_ID || !LIST_ID) return { id: `mock-${Date.now()}` };
+  const r = await fetch(
+    `https://graph.microsoft.com/v1.0/sites/${SITE_ID}/lists/${LIST_ID}/items`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${graphToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ fields }),
+    },
+  );
   if (!r.ok) {
-    const t = await r.text()
-    throw new Error(`Create item failed: ${r.status} ${t}`)
+    const t = await r.text();
+    throw new Error(`Create item failed: ${r.status} ${t}`);
   }
-  return r.json()
+  return r.json();
 }
 
 async function uploadAttachment(graphToken, itemId, name, filePath) {
-  const SITE_ID = process.env.SITE_ID
-  const LIST_ID = process.env.LIST_ID
-  if (!graphToken || !SITE_ID || !LIST_ID) return { name }
-  const b = fs.readFileSync(filePath)
+  const SITE_ID = process.env.SITE_ID;
+  const LIST_ID = process.env.LIST_ID;
+  if (!graphToken || !SITE_ID || !LIST_ID) return { name };
+  const b = fs.readFileSync(filePath);
   const r = await fetch(
     `https://graph.microsoft.com/v1.0/sites/${SITE_ID}/lists/${LIST_ID}/items/${itemId}/driveItem/children/${encodeURIComponent(
-      name
+      name,
     )}:/content`,
-    { method: 'PUT', headers: { Authorization: `Bearer ${graphToken}` }, body: b }
-  )
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${graphToken}` },
+      body: b,
+    },
+  );
   if (!r.ok) {
-    const t = await r.text()
-    throw new Error(`Attach failed: ${r.status} ${t}`)
+    const t = await r.text();
+    throw new Error(`Attach failed: ${r.status} ${t}`);
   }
-  return r.json()
+  return r.json();
 }
 
 // ===== Routes =====
-app.get('/api/health', (_req, res) => res.json({ ok: true }))
+app.get("/api/health", (_req, res) => res.json({ ok: true }));
 
 // SECURITY: Updated upload route with secure file handling
-app.post('/api/upload', requireAuth, secureUpload.array('files'), async (req, res) => {
-  try {
-    const batchId = `batch-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    const batchDir = path.join(TMP_ROOT, batchId)
+app.post(
+  "/api/upload",
+  requireAuth,
+  secureUpload.array("files"),
+  async (req, res) => {
+    try {
+      const files = req.files || [];
+      if (files.length === 0) {
+        return res.status(400).json({ message: "No files uploaded" });
+      }
 
-    // Create batch directory with proper permissions
-    await fs.promises.mkdir(batchDir, { recursive: true, mode: 0o700 })
+      const batchId = `batch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const batchDir = path.join(TMP_ROOT, batchId);
 
-    const results = []
-    for (const f of req.files || []) {
-      // SECURITY: Use sanitized filename instead of originalname
-      const secureFilename = f.secureFilename || `${crypto.randomUUID()}.tmp`
-      const dest = path.join(batchDir, secureFilename)
+      // Create batch directory with proper permissions
+      await fs.promises.mkdir(batchDir, { recursive: true, mode: 0o700 });
 
-      // Move file using async operation
-      await fs.promises.rename(f.path, dest)
+      const results = [];
+      for (const f of files) {
+        // SECURITY: Use sanitized filename instead of originalname
+        const secureFilename = f.secureFilename || `${crypto.randomUUID()}.tmp`;
+        const dest = path.join(batchDir, secureFilename);
 
-      // Process with OCR
-      const data = await analyzeReceipt(dest)
+        // Move file using async operation
+        await fs.promises.rename(f.path, dest);
 
-      results.push({
-        file: f.originalname, // Still show original name to user
-        secureFile: secureFilename, // Track secure filename internally
-        data
-      })
+        // Process with OCR
+        const data = await analyzeReceipt(dest);
+
+        results.push({
+          file: f.originalname, // Still show original name to user
+          secureFile: secureFilename, // Track secure filename internally
+          data,
+        });
+      }
+
+      const fields = results[0]?.data || {};
+      res.json({ results, fields, batchId });
+    } catch (e) {
+      console.error("Upload error:", e);
+      res.status(500).json({ message: e.message });
     }
-
-    const fields = results[0]?.data || {}
-    res.json({ results, fields, batchId })
-  } catch (e) {
-    console.error('Upload error:', e)
-    res.status(500).json({ message: e.message })
-  }
-})
+  },
+);
 
 // Add upload error handling middleware
-app.use('/api/upload', handleUploadErrors)
+app.use("/api/upload", handleUploadErrors);
 
-app.post('/api/submit', requireAuth, async (req, res) => {
+app.post("/api/submit", requireAuth, async (req, res) => {
   try {
-    const { fields, signatureDataUrl, batchId } = req.body || {}
-    const token = await getGraphToken()
-    const item = await createListItem(token, fields || {})
-    const itemId = item?.id || item?.value?.id || item?.name || `mock-${Date.now()}`
+    const { fields, signatureDataUrl, batchId } = req.body || {};
+    const token = await getGraphToken();
+    const item = await createListItem(token, fields || {});
+    const itemId =
+      item?.id || item?.value?.id || item?.name || `mock-${Date.now()}`;
 
     if (batchId) {
-      const batchDir = path.join(TMP_ROOT, batchId)
+      const batchDir = path.join(TMP_ROOT, batchId);
       if (fs.existsSync(batchDir)) {
-        const files = await fs.promises.readdir(batchDir)
+        const files = await fs.promises.readdir(batchDir);
         for (const name of files) {
-          const filePath = path.join(batchDir, name)
-          await uploadAttachment(token, itemId, name, filePath)
+          const filePath = path.join(batchDir, name);
+          await uploadAttachment(token, itemId, name, filePath);
         }
 
         // Clean up files asynchronously
         for (const name of files) {
-          await fs.promises.unlink(path.join(batchDir, name))
+          await fs.promises.unlink(path.join(batchDir, name));
         }
-        await fs.promises.rmdir(batchDir)
+        await fs.promises.rmdir(batchDir);
       }
     }
 
-    if (signatureDataUrl?.startsWith('data:image/png;base64,')) {
-      const m = signatureDataUrl.match(/^data:image\/png;base64,(.+)$/)
+    if (signatureDataUrl?.startsWith("data:image/png;base64,")) {
+      const m = signatureDataUrl.match(/^data:image\/png;base64,(.+)$/);
       if (m) {
-        const tmp = path.join(TMP_ROOT, `sig-${Date.now()}.png`)
-        await fs.promises.writeFile(tmp, Buffer.from(m[1], 'base64'))
-        await uploadAttachment(token, itemId, 'signature.png', tmp)
-        await fs.promises.unlink(tmp)
+        const tmp = path.join(TMP_ROOT, `sig-${Date.now()}.png`);
+        await fs.promises.writeFile(tmp, Buffer.from(m[1], "base64"));
+        await uploadAttachment(token, itemId, "signature.png", tmp);
+        await fs.promises.unlink(tmp);
       }
     }
 
-    res.json({ ok: true, itemId })
+    res.json({ ok: true, itemId });
   } catch (e) {
-    console.error('Submit error:', e)
-    res.status(500).json({ message: e.message })
+    console.error("Submit error:", e);
+    res.status(500).json({ message: e.message });
   }
-})
-
+});
 
 // Global error handler
 app.use((err, req, res, next) => {
-  console.error('Unhandled error:', err)
-  res.status(500).json({ message: 'Internal server error' })
-})
+  console.error("Unhandled error:", err);
+  res.status(500).json({ message: "Internal server error" });
+});
 
-app.listen(port, () => console.log(`API listening on :${port}`))
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => console.log(`API listening on :${port}`));
+}
 
-export default app
+export default app;

--- a/apps/server/tests/security.test.js
+++ b/apps/server/tests/security.test.js
@@ -1,0 +1,209 @@
+import request from "supertest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Mock environment for testing
+process.env.SKIP_AUTH = "true";
+process.env.NODE_ENV = "test";
+
+// Import app after setting env
+const { default: app } = await import("../src/server.js");
+
+describe("File Upload Security Tests", () => {
+  let testImageBuffer;
+  let testPdfBuffer;
+
+  beforeAll(() => {
+    // Create test files
+    testImageBuffer = Buffer.from("fake-image-data");
+    testPdfBuffer = Buffer.from("%PDF-1.4 fake pdf content");
+  });
+
+  afterAll(() => {
+    // Cleanup any test files
+    // Note: In a real app, you'd clean up test directories
+  });
+
+  describe("Path Traversal Protection", () => {
+    test("should reject path traversal attempts in filename", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testImageBuffer, "../../../etc/passwd")
+        .expect(400);
+
+      expect(response.body.message).toContain("not allowed");
+    });
+
+    test("should reject absolute path attempts", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testImageBuffer, "/etc/hosts")
+        .expect(400);
+
+      expect(response.body.message).toContain("not allowed");
+    });
+
+    test("should reject Windows path traversal", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach(
+          "files",
+          testImageBuffer,
+          "..\\..\\..\\windows\\system32\\hosts",
+        )
+        .expect(400);
+
+      expect(response.body.message).toContain("not allowed");
+    });
+
+    test("should accept safe filenames", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testImageBuffer, "receipt.jpg")
+        .expect(200);
+
+      expect(response.body.batchId).toBeDefined();
+      expect(response.body.results).toBeDefined();
+    });
+  });
+
+  describe("File Type Validation", () => {
+    test("should reject executable files", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", Buffer.from("fake exe"), "malware.exe")
+        .expect(400);
+
+      expect(response.body.message).toContain("not allowed");
+    });
+
+    test("should reject script files", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", Buffer.from('alert("xss")'), "script.js")
+        .expect(400);
+
+      expect(response.body.message).toContain("not allowed");
+    });
+
+    test("should accept valid image files", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testImageBuffer, "receipt.jpg")
+        .expect(200);
+
+      expect(response.body.results[0].file).toBe("receipt.jpg");
+    });
+
+    test("should accept valid PDF files", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testPdfBuffer, "receipt.pdf")
+        .expect(200);
+
+      expect(response.body.results[0].file).toBe("receipt.pdf");
+    });
+  });
+
+  describe("File Size Limits", () => {
+    test("should reject files that are too large", async () => {
+      const largeBuffer = Buffer.alloc(15 * 1024 * 1024); // 15MB
+
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", largeBuffer, "large.jpg")
+        .expect(413);
+
+      expect(response.body.message).toContain("too large");
+    });
+
+    test("should accept files within size limit", async () => {
+      const smallBuffer = Buffer.alloc(1024); // 1KB
+
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", smallBuffer, "small.jpg")
+        .expect(200);
+
+      expect(response.body.results).toBeDefined();
+    });
+
+    test("should reject too many files", async () => {
+      const req = request(app).post("/api/upload");
+
+      // Attach 6 files (limit is 5)
+      for (let i = 0; i < 6; i++) {
+        req.attach("files", testImageBuffer, `file${i}.jpg`);
+      }
+
+      const response = await req.expect(413);
+      expect(response.body.message).toContain("Too many files");
+    });
+  });
+
+  describe("Rate Limiting", () => {
+    test("should allow normal upload rate", async () => {
+      const response = await request(app)
+        .post("/api/upload")
+        .attach("files", testImageBuffer, "test.jpg")
+        .expect(200);
+
+      expect(response.body.results).toBeDefined();
+    });
+
+    // Note: Rate limiting tests are complex due to timing
+    // In a real scenario, you'd use a test helper to simulate rapid requests
+  });
+});
+
+describe("API Health and Basic Functionality", () => {
+  test("health endpoint should return ok", async () => {
+    const response = await request(app).get("/api/health").expect(200);
+
+    expect(response.body.ok).toBe(true);
+  });
+
+  test("should handle empty upload gracefully", async () => {
+    const response = await request(app).post("/api/upload").expect(400);
+
+    expect(response.body.message).toBeDefined();
+  });
+
+  test("should handle invalid routes", async () => {
+    const response = await request(app).get("/api/nonexistent").expect(404);
+  });
+});
+
+describe("Submit Endpoint", () => {
+  test("should handle submit with valid data", async () => {
+    const submitData = {
+      fields: {
+        vendor: "Test Store",
+        total: "12.34",
+        transactionDate: "2024-01-01",
+      },
+      batchId: "test-batch-123",
+    };
+
+    const response = await request(app)
+      .post("/api/submit")
+      .send(submitData)
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.itemId).toBeDefined();
+  });
+
+  test("should handle submit with empty data", async () => {
+    const response = await request(app)
+      .post("/api/submit")
+      .send({})
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config for server tests
- cover upload security, file validation, and API basics
- adjust server for test environment and stricter validation

## Testing
- `npm test --workspace=apps/server -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a0fb9b20888332b2429c75429a3b39