### PR TITLE
test: configure Jest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,31 @@
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "cross-env": "^7.0.3"
+  },
+  "jest": {
+    "preset": "jest-environment-node",
+    "testEnvironment": "node",
+    "transform": {},
+    "extensionsToTreatAsEsm": [
+      ".js"
+    ],
+    "globals": {
+      "jest": {
+        "useESM": true
+      }
+    },
+    "moduleNameMapping": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "testMatch": [
+      "**/tests/**/*.test.js"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.js",
+      "!src/server.js"
+    ],
+    "setupFiles": [
+      "<rootDir>/tests/setup.js"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration for Node-based testing

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a103a497108332ab17c1524741fc2b