### PR TITLE
fix: harden server security configuration

### DIFF
--- a/apps/server/src/middleware/secureUpload.js
+++ b/apps/server/src/middleware/secureUpload.js
@@ -7,8 +7,8 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const TMP_ROOT = path.join(__dirname, "../../.tmp");
-fs.mkdirSync(TMP_ROOT, { recursive: true });
+const TMP_ROOT = path.join(__dirname, "../../.tmp")
+fs.mkdirSync(TMP_ROOT, { recursive: true, mode: 0o700 })
 
 // Allowed file extensions and MIME types
 const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".pdf"];


### PR DESCRIPTION
## Summary
- validate required environment variables
- make rate limiting and CORS origins configurable
- add production security headers and safer temp directory cleanup

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a21cb1a8988332a4954d6cf2a460c9