### PR TITLE
fix: validate batchId to prevent path traversal

### DIFF
--- a/apps/server/tests/security.test.js
+++ b/apps/server/tests/security.test.js
@@ -186,7 +186,7 @@ describe("Submit Endpoint", () => {
         total: "12.34",
         transactionDate: "2024-01-01",
       },
-      batchId: "test-batch-123",
+      batchId: "batch-123-abc",
     };
 
     const response = await request(app)
@@ -224,4 +224,31 @@ describe("Submit Endpoint", () => {
 
     expect(response.body.message).toContain("Invalid type")
   })
-});
+
+  test('should reject path traversal in batchId', async () => {
+    const response = await request(app)
+      .post('/api/submit')
+      .send({ batchId: '../etc/passwd', fields: {} })
+      .expect(400)
+
+    expect(response.body.message).toContain('Invalid batchId')
+  })
+
+  test('should reject absolute batchId path', async () => {
+    const response = await request(app)
+      .post('/api/submit')
+      .send({ batchId: '/etc/passwd', fields: {} })
+      .expect(400)
+
+    expect(response.body.message).toContain('Invalid batchId')
+  })
+
+  test('should reject windows style traversal', async () => {
+    const response = await request(app)
+      .post('/api/submit')
+      .send({ batchId: '..\\..\\evil', fields: {} })
+      .expect(400)
+
+    expect(response.body.message).toContain('Invalid batchId')
+  })
+})


### PR DESCRIPTION
## Summary
- validate `batchId` with strict regex and safe path resolution
- add tests rejecting batchId path traversal attempts

## Testing
- `npm --prefix apps/server test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a234b04f408332a05e904d77c458a9