### PR TITLE
fix: gate auth bypass behind env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Fill in root `.env`:
 - `SCOPE_NAME` — Scope name on API app, e.g., `access_as_user`
 - `SITE_ID`, `LIST_ID` — Your SharePoint targets
 - `AZURE_DOC_INTELLIGENCE_ENDPOINT`, `AZURE_DOC_INTELLIGENCE_KEY`
+- `AUTH_BYPASS` — set to `true` only for local tests to disable auth (never set in production)
 
 Fill in `apps/web/.env`:
 ```

--- a/apps/server/src/server.js
+++ b/apps/server/src/server.js
@@ -162,7 +162,7 @@ async function validateAADToken(token) {
 }
 
 function requireAuth(req, res, next) {
-  if (process.env.NODE_ENV === "test") return next()
+  if (process.env.AUTH_BYPASS === "true") return next()
   const h = req.headers.authorization || ""
   const token = h.startsWith("Bearer ") ? h.slice(7) : null
   if (!token) return res.status(401).json({ message: "Missing bearer token" })

--- a/apps/server/tests/security.test.js
+++ b/apps/server/tests/security.test.js
@@ -7,8 +7,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Mock environment for testing
-process.env.SKIP_AUTH = "true";
-process.env.NODE_ENV = "test";
+process.env.AUTH_BYPASS = "true"
+process.env.NODE_ENV = "test"
 
 // Import app after setting env
 const { default: app } = await import("../src/server.js");


### PR DESCRIPTION
## Summary
- require explicit `AUTH_BYPASS` flag to skip auth
- enable `AUTH_BYPASS` in integration tests
- document `AUTH_BYPASS` to prevent accidental production use

## Testing
- `npm --prefix apps/server test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a2368e85308332a5161eee498aa272