### PR TITLE
feat: add file type validation

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,7 +17,8 @@
     "form-data": "^4.0.0",
     "jose": "^5.9.6",
     "multer": "^1.4.5-lts.1",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "file-type": "^18.5.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- add file-type dependency
- validate uploaded files against detected MIME type
- test blocking spoofed MIME types

## Testing
- `npm --prefix apps/server test -- --watchAll=false` *(fails: expected 200 OK, got 400 Bad Request)*

------
https://chatgpt.com/codex/tasks/task_b_68a2382edb3083329b1794989aff3fed