### PR TITLE
feat: secure server with helmet

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,7 +18,8 @@
     "jose": "^5.9.6",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",
-    "file-type": "^18.5.0"
+    "file-type": "^18.5.0",
+    "helmet": "^7.1.2"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- add Helmet with HTTPS redirect and minimal CSP
- enable trust proxy and drop manual security headers
- include Helmet dependency

## Testing
- `npm --prefix apps/server test -- --watchAll=false` *(fails: Cannot find module 'helmet')*


------
https://chatgpt.com/codex/tasks/task_b_68a2415bc75c8332b8ef73b196a3b557