### PR TITLE
feat: refine button styling

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -43,34 +43,38 @@ function NavBar() {
         <h1 className='text-xl font-semibold'>Receipt Extractor</h1>
         <div className='hidden md:block lg:block'>
           <div className='flex space-x-4'>
-            <NavLink to='/'>Upload</NavLink>
-            <NavLink to='/review'>Review</NavLink>
-            <NavLink to='/signature'>Signature</NavLink>
-            <NavLink to='/submit'>Submit</NavLink>
+            <NavLink to='/' variant='primary'>Upload</NavLink>
+            <NavLink to='/review' variant='secondary'>Review</NavLink>
+            <NavLink to='/signature' variant='secondary'>Signature</NavLink>
+            <NavLink to='/submit' variant='primary'>Submit</NavLink>
           </div>
         </div>
       </div>
       <div className='flex flex-col items-center md:hidden space-y-2 mt-2'>
-        <NavLink to='/'>Upload</NavLink>
-        <NavLink to='/review'>Review</NavLink>
-        <NavLink to='/signature'>Signature</NavLink>
-        <NavLink to='/submit'>Submit</NavLink>
+        <NavLink to='/' variant='primary'>Upload</NavLink>
+        <NavLink to='/review' variant='secondary'>Review</NavLink>
+        <NavLink to='/signature' variant='secondary'>Signature</NavLink>
+        <NavLink to='/submit' variant='primary'>Submit</NavLink>
       </div>
     </nav>
   )
 }
 
-function NavLink({ to, children }) {
+function NavLink({ to, children, variant }) {
   const navigate = useNavigate()
   const location = useLocation()
   const isActive = location.pathname === to
+  const variantClass =
+    variant === 'primary'
+      ? 'btn-primary'
+      : variant === 'secondary'
+      ? 'btn-secondary'
+      : 'btn-tertiary'
 
   return (
     <button
       onClick={() => navigate(to)}
-      className={`px-4 py-2 rounded transition-all hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-cyan-400 ${
-        isActive ? 'border-b-2 border-cyan-400' : ''
-      }`}
+      className={`${variantClass} ${isActive ? 'border-b-2 border-cyan-500' : ''}`}
     >
       {children}
     </button>

--- a/apps/web/src/components/ErrorBoundary.jsx
+++ b/apps/web/src/components/ErrorBoundary.jsx
@@ -56,15 +56,7 @@ export default class ErrorBoundary extends React.Component {
           )}
           <button
             onClick={() => window.location.reload()}
-            style={{
-              marginTop: '10px',
-              padding: '8px 16px',
-              backgroundColor: '#007bff',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer'
-            }}
+            className='btn-primary mt-2'
           >
             Reload Page
           </button>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9,5 +9,13 @@ body {
 }
 
 .btn-primary {
-  @apply bg-cyan-500 hover:bg-cyan-600 text-white px-4 py-2 rounded transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-cyan-400;
+  @apply inline-flex items-center gap-2 px-4 py-2 bg-cyan-500 text-white rounded transition-all duration-300 hover:bg-cyan-600 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-cyan-500 text-sm md:text-lg;
+}
+
+.btn-secondary {
+  @apply inline-flex items-center gap-2 px-4 py-2 border border-cyan-500 text-cyan-500 rounded transition-all duration-300 hover:bg-cyan-500 hover:text-white hover:scale-105 focus:outline-none focus:ring-2 focus:ring-cyan-500 text-sm md:text-lg;
+}
+
+.btn-tertiary {
+  @apply inline-flex items-center gap-2 px-4 py-2 text-white rounded transition-all duration-300 hover:text-cyan-500 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-cyan-500 text-sm md:text-lg;
 }


### PR DESCRIPTION
## Summary
- refine primary button styling with transitions, spacing, and focus ring
- introduce secondary and tertiary button variants for flexible usage
- apply new variants in navbar and error boundary

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68a3c1dbbcc483329d227a6752609c79