### PR TITLE
feat: integrate styled alerts for user feedback

### DIFF
--- a/apps/web/src/components/Alert.jsx
+++ b/apps/web/src/components/Alert.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+function XCircleIcon({ className }) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+      strokeWidth={1.5}
+      stroke='currentColor'
+      className={className}
+    >
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+      />
+    </svg>
+  )
+}
+
+function CheckCircleIcon({ className }) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+      strokeWidth={1.5}
+      stroke='currentColor'
+      className={className}
+    >
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M9 12.75l2.25 2.25L15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+      />
+    </svg>
+  )
+}
+
+export default function Alert({ type = 'success', className = '', children }) {
+  const Icon = type === 'error' ? XCircleIcon : CheckCircleIcon
+  const bg = type === 'error' ? 'bg-red-600' : 'bg-green-600'
+  return (
+    <div
+      className={`${bg} text-white p-4 rounded-lg flex items-start gap-2 ${className}`}
+      role='alert'
+    >
+      <Icon className='h-5 w-5 shrink-0 mt-0.5' />
+      <div className='flex-1'>{children}</div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/SubmitPage.jsx
+++ b/apps/web/src/pages/SubmitPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import axios from 'axios'
 import { useReceipt } from '../receiptContext.jsx'
 import { getToken } from '../msal.js'
+import Alert from '../components/Alert.jsx'
 
 export default function SubmitPage() {
   const { files, fields, signatureDataUrl, batchId } = useReceipt()
@@ -17,22 +18,26 @@ export default function SubmitPage() {
       })
       setMessage(`Submitted. Item ID: ${res.data.itemId}`)
     } catch (e) {
-      setError(e?.response?.data?.message || e.message)
-    }
+    setError(e?.response?.data?.message || e.message)
   }
+}
 
   return (
     <div>
+      {message && (
+        <Alert type='success' className='mb-4'>
+          {message}
+        </Alert>
+      )}
+      {error && (
+        <Alert type='error' className='mb-4'>
+          {error}
+        </Alert>
+      )}
       <h2>Submit</h2>
       <p>Files: {files.map(f => f.name).join(', ') || 'None'}</p>
       <p>Batch: {batchId || 'n/a'}</p>
       <button className='btn-primary' onClick={onSubmit}>Submit</button>
-      {message && (
-        <p className='bg-green-600 text-white p-4 rounded-lg mt-4'>{message}</p>
-      )}
-      {error && (
-        <p className='bg-red-600 text-white p-4 rounded-lg mt-4'>{error}</p>
-      )}
     </div>
   )
 }

--- a/apps/web/src/pages/UploadPage.jsx
+++ b/apps/web/src/pages/UploadPage.jsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { useReceipt } from '../receiptContext.jsx'
 import { getToken } from '../msal.js'
 import { useNavigate } from 'react-router-dom'
+import Alert from '../components/Alert.jsx'
 
 // File validation constants (must match server)
 const ALLOWED_TYPES = [
@@ -188,6 +189,31 @@ export default function UploadPage() {
 
   return (
     <div>
+      {error && (
+        <Alert type='error' className='mb-4'>
+          {error}
+        </Alert>
+      )}
+
+      {validationInfo && !busy && (
+        <Alert type='success' className='mb-4'>
+          <strong>Files validated successfully</strong>
+          <div className='text-sm mt-2'>
+            {validationInfo.count} file(s) selected • Total size {validationInfo.totalSize}
+          </div>
+          <details className='mt-2 text-sm'>
+            <summary className='cursor-pointer'>File details</summary>
+            <ul className='mt-2 list-disc pl-5'>
+              {validationInfo.files.map((file, idx) => (
+                <li key={idx} className='text-xs mb-1'>
+                  <strong>{file.name}</strong> ({file.size}, {file.type})
+                </li>
+              ))}
+            </ul>
+          </details>
+        </Alert>
+      )}
+
       <h2>Upload Receipts</h2>
 
       <div style={{ marginBottom: '16px' }}>
@@ -209,26 +235,6 @@ export default function UploadPage() {
           {MAX_FILE_SIZE / (1024 * 1024)}MB per file
         </div>
       </div>
-
-      {/* Validation info display */}
-      {validationInfo && !busy && (
-        <div className='bg-green-600 text-white p-4 rounded-lg mb-4'>
-          <strong>✓ Files validated successfully</strong>
-          <div className='text-sm mt-2'>
-            {validationInfo.count} file(s) selected • Total size {validationInfo.totalSize}
-          </div>
-          <details className='mt-2 text-sm'>
-            <summary className='cursor-pointer'>File details</summary>
-            <ul className='mt-2 list-disc pl-5'>
-              {validationInfo.files.map((file, idx) => (
-                <li key={idx} className='text-xs mb-1'>
-                  <strong>{file.name}</strong> ({file.size}, {file.type})
-                </li>
-              ))}
-            </ul>
-          </details>
-        </div>
-      )}
 
       {/* Processing indicator */}
       {busy && (
@@ -269,13 +275,6 @@ export default function UploadPage() {
               </div>
             </div>
           </div>
-        </div>
-      )}
-
-      {/* Error display */}
-      {error && (
-        <div className='bg-red-600 text-white p-4 rounded-lg mb-4'>
-          <strong>❌ Error:</strong> {error}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add reusable `Alert` component with XCircle and CheckCircle icons
- show alert messages above content on upload and submit pages

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a3c332e244833282a4fa5841d5b7b4