### PR TITLE
feat: make receipt pages responsive

### DIFF
--- a/apps/web/src/pages/ReviewPage.jsx
+++ b/apps/web/src/pages/ReviewPage.jsx
@@ -8,13 +8,19 @@ export default function ReviewPage() {
 
   const keys = Object.keys(fields || {})
   return (
-    <div>
-      <h2>Review</h2>
-      {keys.length === 0 && <p>No fields yet. Upload a receipt first.</p>}
+    <div className='max-w-screen w-full px-4 mx-auto'>
+      <h2 className='text-xl sm:text-2xl md:text-3xl mb-4 sm:mb-6'>Review</h2>
+      {keys.length === 0 && (
+        <p className='text-sm sm:text-base'>No fields yet. Upload a receipt first.</p>
+      )}
       {keys.map(k => (
-        <div key={k} style={{marginBottom:8}}>
-          <label style={{display:'block', fontWeight:600}}>{k}</label>
-          <input value={fields[k] ?? ''} onChange={e => update(k, e.target.value)} />
+        <div key={k} className='mb-2 sm:mb-4'>
+          <label className='block font-semibold text-sm sm:text-base md:text-lg'>{k}</label>
+          <input
+            className='mt-1 w-full p-1 sm:p-2 border rounded text-sm sm:text-base md:text-lg'
+            value={fields[k] ?? ''}
+            onChange={e => update(k, e.target.value)}
+          />
         </div>
       ))}
     </div>

--- a/apps/web/src/pages/SubmitPage.jsx
+++ b/apps/web/src/pages/SubmitPage.jsx
@@ -23,21 +23,21 @@ export default function SubmitPage() {
 }
 
   return (
-    <div>
+    <div className='max-w-screen w-full px-4 mx-auto'>
       {message && (
-        <Alert type='success' className='mb-4'>
+        <Alert type='success' className='mb-4 sm:mb-6 md:mb-8'>
           {message}
         </Alert>
       )}
       {error && (
-        <Alert type='error' className='mb-4'>
+        <Alert type='error' className='mb-4 sm:mb-6 md:mb-8'>
           {error}
         </Alert>
       )}
-      <h2>Submit</h2>
-      <p>Files: {files.map(f => f.name).join(', ') || 'None'}</p>
-      <p>Batch: {batchId || 'n/a'}</p>
-      <button className='btn-primary' onClick={onSubmit}>Submit</button>
+      <h2 className='text-xl sm:text-2xl md:text-3xl mb-4 sm:mb-6'>Submit</h2>
+      <p className='mb-2 sm:mb-3 text-sm sm:text-base'>Files: {files.map(f => f.name).join(', ') || 'None'}</p>
+      <p className='mb-4 sm:mb-6 text-sm sm:text-base'>Batch: {batchId || 'n/a'}</p>
+      <button className='btn-primary text-sm sm:text-base' onClick={onSubmit}>Submit</button>
     </div>
   )
 }

--- a/apps/web/src/pages/UploadPage.jsx
+++ b/apps/web/src/pages/UploadPage.jsx
@@ -188,24 +188,24 @@ export default function UploadPage() {
   }
 
   return (
-    <div>
+    <div className='max-w-screen w-full px-4 mx-auto'>
       {error && (
-        <Alert type='error' className='mb-4'>
+        <Alert type='error' className='mb-4 sm:mb-6 md:mb-8'>
           {error}
         </Alert>
       )}
 
       {validationInfo && !busy && (
-        <Alert type='success' className='mb-4'>
+        <Alert type='success' className='mb-4 sm:mb-6 md:mb-8'>
           <strong>Files validated successfully</strong>
-          <div className='text-sm mt-2'>
+          <div className='text-sm mt-2 sm:text-base md:text-lg'>
             {validationInfo.count} file(s) selected • Total size {validationInfo.totalSize}
           </div>
-          <details className='mt-2 text-sm'>
+          <details className='mt-2 text-sm sm:text-base'>
             <summary className='cursor-pointer'>File details</summary>
             <ul className='mt-2 list-disc pl-5'>
               {validationInfo.files.map((file, idx) => (
-                <li key={idx} className='text-xs mb-1'>
+                <li key={idx} className='text-xs mb-1 sm:text-sm'>
                   <strong>{file.name}</strong> ({file.size}, {file.type})
                 </li>
               ))}
@@ -214,23 +214,18 @@ export default function UploadPage() {
         </Alert>
       )}
 
-      <h2>Upload Receipts</h2>
+      <h2 className='text-xl sm:text-2xl md:text-3xl mb-4 sm:mb-6'>Upload Receipts</h2>
 
-      <div style={{ marginBottom: '16px' }}>
+      <div className='mb-4 sm:mb-6'>
         <input
-          type="file"
-          accept="image/jpeg,image/jpg,image/png,image/gif,application/pdf"
+          type='file'
+          accept='image/jpeg,image/jpg,image/png,image/gif,application/pdf'
           multiple
           onChange={onSelect}
           disabled={busy}
-          style={{
-            padding: '8px',
-            border: '2px dashed #ccc',
-            borderRadius: '4px',
-            cursor: busy ? 'not-allowed' : 'pointer',
-          }}
+          className='p-2 border-2 border-dashed border-gray-300 rounded cursor-pointer disabled:cursor-not-allowed w-full sm:w-auto'
         />
-        <div style={{ fontSize: '12px', color: '#666', marginTop: '4px' }}>
+        <div className='text-xs text-gray-600 mt-1 sm:text-sm md:text-base'>
           Supported: JPG, PNG, GIF, PDF • Max {MAX_FILES} files • Max{' '}
           {MAX_FILE_SIZE / (1024 * 1024)}MB per file
         </div>
@@ -238,39 +233,14 @@ export default function UploadPage() {
 
       {/* Processing indicator */}
       {busy && (
-        <div
-          style={{
-            padding: '16px',
-            backgroundColor: '#e3f2fd',
-            border: '1px solid #2196f3',
-            borderRadius: '4px',
-            marginBottom: '16px',
-            textAlign: 'center'
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: '12px'
-            }}
-          >
-            <div
-              style={{
-                width: '20px',
-                height: '20px',
-                border: '3px solid #2196f3',
-                borderTop: '3px solid transparent',
-                borderRadius: '50%',
-                animation: 'spin 1s linear infinite',
-              }}
-            ></div>
+        <div className='p-4 sm:p-6 bg-blue-50 border border-blue-500 rounded mb-4 sm:mb-6 text-center'>
+          <div className='flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 md:gap-6'>
+            <div className='w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin'></div>
             <div>
-              <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
+              <div className='font-bold mb-1 sm:mb-0'>
                 Processing Receipt
               </div>
-              <div style={{ fontSize: '14px', color: '#666' }}>
+              <div className='text-sm sm:text-base text-gray-600'>
                 Extracting data with OCR technology...
               </div>
             </div>


### PR DESCRIPTION
## Summary
- wrap Upload, Review, and Submit pages with responsive containers
- add mobile-first spacing, flex, and font-size utilities

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script: "test")*
- `npm --prefix apps/web run build`


------
https://chatgpt.com/codex/tasks/task_b_68a3d41409488332b38baeaa3738a7ce