### PR TITLE
test: add mobile e2e flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,18 @@
+name: e2e
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npx playwright install --with-deps
+      - run: npm --prefix apps/web run test:e2e

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@azure/msal-browser": "^3.12.0",
@@ -19,6 +20,7 @@
     "vite": "^5.4.1",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "@playwright/test": "^1.45.3"
   }
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+    viewport: { width: 375, height: 667 }
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    env: { VITE_E2E: 'true' }
+  }
+})

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -10,9 +10,11 @@ import ErrorBoundary from './components/ErrorBoundary.jsx'
 
 export default function App() {
   useEffect(() => {
-    initMsal().catch((error) => {
-      console.error('MSAL init error:', error)
-    })
+    if (import.meta.env.VITE_E2E !== 'true') {
+      initMsal().catch((error) => {
+        console.error('MSAL init error:', error)
+      })
+    }
   }, [])
 
   return (

--- a/apps/web/tests/mobile.spec.ts
+++ b/apps/web/tests/mobile.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6X1t6wAAAAASUVORK5CYII=',
+  'base64'
+)
+
+test('mobile receipt flow', async ({ page }) => {
+  await page.route('**/api/upload', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ fields: { total: '1.23' }, batchId: 'b123' })
+    })
+  })
+
+  await page.route('**/api/submit', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ itemId: 'i123' })
+    })
+  })
+
+  await page.goto('/')
+
+  await page.setInputFiles('input[type="file"]', {
+    name: 'test.png',
+    mimeType: 'image/png',
+    buffer: png
+  })
+
+  await expect(page).toHaveURL(/review/)
+
+  await page.click('button[aria-controls="main-menu"]')
+  await page.click('text=Signature')
+  await expect(page).toHaveURL(/signature/)
+
+  const canvas = page.locator('canvas')
+  const box = await canvas.boundingBox()
+  if (box) {
+    await page.mouse.move(box.x + 10, box.y + 10)
+    await page.mouse.down()
+    await page.mouse.move(box.x + 60, box.y + 40)
+    await page.mouse.up()
+  }
+
+  await page.click('button[aria-controls="main-menu"]')
+  await page.click('text=Submit')
+  await expect(page).toHaveURL(/submit/)
+
+  await page.click('text=Submit')
+  await expect(page.getByText('Submitted')).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- skip MSAL init during Playwright runs
- add Playwright config and mobile flow e2e test
- run e2e tests in CI

## Testing
- `npm test -- --watchAll=false` (fails: Missing script: "test")
- `npm --prefix apps/web run test:e2e` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_b_68a4a77762dc83328b8bf8f82deab831